### PR TITLE
Fix print_size when batch is present

### DIFF
--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -290,7 +290,7 @@ class DataProto:
 
     def print_size(self, prefix=""):
         size_of_tensordict = 0
-        if self.batch is None:
+        if self.batch is not None:
             for key, tensor in self.batch.items():
                 size_of_tensordict += tensor.element_size() * tensor.numel()
         size_of_numpy_array = 0


### PR DESCRIPTION
## Summary
- fix a condition in `DataProto.print_size`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683fb15e67f8832c878f2989243f3b41